### PR TITLE
Adapts action tests to new fs interface

### DIFF
--- a/pkg/elemental/elemental.go
+++ b/pkg/elemental/elemental.go
@@ -341,7 +341,9 @@ func (c *Elemental) CopyImage(img *v1.Image) error { // nolint:gocyclo
 		if err != nil {
 			return err
 		}
-	} else if img.Source.IsFile() {
+	}
+
+	if img.Source.IsFile() {
 		err := utils.MkdirAll(c.config.Fs, filepath.Dir(img.File), cnst.DirPerm)
 		if err != nil {
 			return err
@@ -358,10 +360,12 @@ func (c *Elemental) CopyImage(img *v1.Image) error { // nolint:gocyclo
 				return err
 			}
 		}
-	}
-	err = utils.CreateDirStructure(c.config.Fs, img.MountPoint)
-	if err != nil {
-		return err
+	} else {
+		err = utils.CreateDirStructure(c.config.Fs, img.MountPoint)
+		if err != nil {
+			fmt.Println("failed creating dir structure")
+			return err
+		}
 	}
 	c.config.Logger.Infof("Finished copying %s...", img.Label)
 	return nil

--- a/pkg/elemental/elemental_test.go
+++ b/pkg/elemental/elemental_test.go
@@ -77,7 +77,7 @@ var _ = Describe("Elemental", Label("elemental"), func() {
 	Describe("MountPartitions", Label("MountPartitions", "disk", "partition", "mount"), func() {
 		var el *elemental.Elemental
 		BeforeEach(func() {
-			utils.MkdirAll(fs, filepath.Dir(cnst.EfiDevice), os.ModePerm)
+			utils.MkdirAll(fs, filepath.Dir(cnst.EfiDevice), cnst.DirPerm)
 			_, err := fs.Create(cnst.EfiDevice)
 			Expect(err).ToNot(HaveOccurred())
 			action.InstallSetup(config)
@@ -116,9 +116,9 @@ var _ = Describe("Elemental", Label("elemental"), func() {
 		var el *elemental.Elemental
 		BeforeEach(func() {
 			runner.ReturnValue = []byte("/some/device")
-			utils.MkdirAll(fs, filepath.Dir("/some"), os.ModePerm)
+			utils.MkdirAll(fs, filepath.Dir("/some"), cnst.DirPerm)
 
-			utils.MkdirAll(fs, filepath.Dir(cnst.EfiDevice), os.ModePerm)
+			utils.MkdirAll(fs, filepath.Dir(cnst.EfiDevice), cnst.DirPerm)
 			_, err := fs.Create(cnst.EfiDevice)
 			Expect(err).ShouldNot(HaveOccurred())
 
@@ -253,7 +253,7 @@ var _ = Describe("Elemental", Label("elemental"), func() {
 		BeforeEach(func() {
 			cInit = &v1mock.FakeCloudInitRunner{ExecStages: []string{}, Error: false}
 			config.CloudInitRunner = cInit
-			utils.MkdirAll(fs, filepath.Dir(cnst.EfiDevice), os.ModePerm)
+			utils.MkdirAll(fs, filepath.Dir(cnst.EfiDevice), cnst.DirPerm)
 			_, err := fs.Create(cnst.EfiDevice)
 			Expect(err).ToNot(HaveOccurred())
 			el = elemental.NewElemental(config)
@@ -686,7 +686,7 @@ var _ = Describe("Elemental", Label("elemental"), func() {
 		It("Gets the iso and returns the temporary where it is stored and no image sources are set", func() {
 			tmpDir, err := utils.TempDir(fs, "", "elemental-test")
 			Expect(err).To(BeNil())
-			err = fs.WriteFile(fmt.Sprintf("%s/fake.iso", tmpDir), []byte("Hi"), os.ModePerm)
+			err = fs.WriteFile(fmt.Sprintf("%s/fake.iso", tmpDir), []byte("Hi"), cnst.FilePerm)
 			Expect(err).To(BeNil())
 			config.Iso = fmt.Sprintf("%s/fake.iso", tmpDir)
 			e := elemental.NewElemental(config)
@@ -700,7 +700,7 @@ var _ = Describe("Elemental", Label("elemental"), func() {
 		It("Gets the iso and sets active and recovery images", func() {
 			tmpDir, err := utils.TempDir(fs, "", "elemental-test")
 			Expect(err).To(BeNil())
-			err = fs.WriteFile(fmt.Sprintf("%s/fake.iso", tmpDir), []byte("Hi"), os.ModePerm)
+			err = fs.WriteFile(fmt.Sprintf("%s/fake.iso", tmpDir), []byte("Hi"), cnst.FilePerm)
 			Expect(err).To(BeNil())
 			config.Iso = fmt.Sprintf("%s/fake.iso", tmpDir)
 			config.Images[cnst.ActiveImgName] = &v1.Image{File: "activeimagefile"}
@@ -716,7 +716,7 @@ var _ = Describe("Elemental", Label("elemental"), func() {
 		It("Fails if attemps to set recovery from active but no active is defined", func() {
 			tmpDir, err := utils.TempDir(fs, "", "elemental-test")
 			Expect(err).To(BeNil())
-			err = fs.WriteFile(fmt.Sprintf("%s/fake.iso", tmpDir), []byte("Hi"), os.ModePerm)
+			err = fs.WriteFile(fmt.Sprintf("%s/fake.iso", tmpDir), []byte("Hi"), cnst.FilePerm)
 			Expect(err).To(BeNil())
 			config.Iso = fmt.Sprintf("%s/fake.iso", tmpDir)
 			config.Images[cnst.RecoveryImgName] = &v1.Image{}
@@ -734,7 +734,7 @@ var _ = Describe("Elemental", Label("elemental"), func() {
 			config.Mounter = v1mock.ErrorMounter{ErrorOnMount: true}
 			tmpDir, err := utils.TempDir(fs, "", "elemental-test")
 			Expect(err).To(BeNil())
-			err = fs.WriteFile(fmt.Sprintf("%s/fake.iso", tmpDir), []byte("Hi"), os.ModePerm)
+			err = fs.WriteFile(fmt.Sprintf("%s/fake.iso", tmpDir), []byte("Hi"), cnst.FilePerm)
 			Expect(err).To(BeNil())
 			config.Iso = fmt.Sprintf("%s/fake.iso", tmpDir)
 			e := elemental.NewElemental(config)
@@ -746,7 +746,7 @@ var _ = Describe("Elemental", Label("elemental"), func() {
 	Describe("CloudConfig", Label("CloudConfig", "cloud-config"), func() {
 		It("Copies the cloud config file", func() {
 			testString := "In a galaxy far far away..."
-			err := fs.WriteFile("/config.yaml", []byte(testString), os.ModePerm)
+			err := fs.WriteFile("/config.yaml", []byte(testString), cnst.FilePerm)
 			Expect(err).To(BeNil())
 			Expect(err).To(BeNil())
 			config.CloudInit = "/config.yaml"

--- a/pkg/utils/common.go
+++ b/pkg/utils/common.go
@@ -119,8 +119,8 @@ func CopyFile(fs v1.FS, source string, target string) (err error) {
 
 // Copies source file to target file using Fs interface
 func CreateDirStructure(fs v1.FS, target string) error {
-	for _, dir := range []string{"run", "sys", "proc", "dev", "tmp", "boot", "usr/local", "oem"} {
-		err := MkdirAll(fs, fmt.Sprintf("%s/%s", target, dir), cnst.DirPerm)
+	for _, dir := range []string{"/run", "/sys", "/proc", "/dev", "/tmp", "/boot", "/usr/local", "/oem"} {
+		err := MkdirAll(fs, filepath.Join(target, dir), cnst.DirPerm)
 		if err != nil {
 			return err
 		}

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -64,9 +64,9 @@ var _ = Describe("Utils", Label("utils"), func() {
 		logger = v1.NewNullLogger()
 		// Ensure /tmp exists in the VFS
 		fs, cleanup, _ = vfst.NewTestFS(nil)
-		fs.Mkdir("/tmp", os.ModePerm)
-		fs.Mkdir("/run", os.ModePerm)
-		fs.Mkdir("/etc", os.ModePerm)
+		fs.Mkdir("/tmp", constants.DirPerm)
+		fs.Mkdir("/run", constants.DirPerm)
+		fs.Mkdir("/etc", constants.DirPerm)
 
 		config = conf.NewRunConfig(
 			v1.WithFs(fs),
@@ -319,7 +319,7 @@ var _ = Describe("Utils", Label("utils"), func() {
 	})
 	Describe("CopyFile", Label("CopyFile"), func() {
 		It("Copies source to target", func() {
-			err := utils.MkdirAll(fs, "/some", os.ModePerm)
+			err := utils.MkdirAll(fs, "/some", constants.DirPerm)
 			Expect(err).ShouldNot(HaveOccurred())
 			_, err = fs.Create("/some/file")
 			Expect(err).ShouldNot(HaveOccurred())
@@ -333,14 +333,14 @@ var _ = Describe("Utils", Label("utils"), func() {
 			Expect(e).To(BeTrue())
 		})
 		It("Fails to open non existing file", func() {
-			err := utils.MkdirAll(fs, "/some", os.ModePerm)
+			err := utils.MkdirAll(fs, "/some", constants.DirPerm)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(utils.CopyFile(fs, "/some/file", "/some/otherfile")).NotTo(BeNil())
 			_, err = fs.Stat("/some/otherfile")
 			Expect(err).NotTo(BeNil())
 		})
 		It("Fails to copy on non writable target", func() {
-			err := utils.MkdirAll(fs, "/some", os.ModePerm)
+			err := utils.MkdirAll(fs, "/some", constants.DirPerm)
 			Expect(err).ShouldNot(HaveOccurred())
 			fs.Create("/some/file")
 			_, err = fs.Stat("/some/otherfile")
@@ -400,8 +400,8 @@ var _ = Describe("Utils", Label("utils"), func() {
 			Expect(err).To(BeNil())
 			defer os.RemoveAll(destDir)
 
-			os.MkdirAll(filepath.Join(sourceDir, "host"), os.ModePerm)
-			os.MkdirAll(filepath.Join(sourceDir, "run"), os.ModePerm)
+			os.MkdirAll(filepath.Join(sourceDir, "host"), constants.DirPerm)
+			os.MkdirAll(filepath.Join(sourceDir, "run"), constants.DirPerm)
 			for i := 0; i < 5; i++ {
 				_, _ = os.CreateTemp(sourceDir, "file*")
 			}
@@ -515,7 +515,7 @@ var _ = Describe("Utils", Label("utils"), func() {
 				err := utils.MkdirAll(fs, fmt.Sprintf("%s/grub2/", constants.StateDir), 0666)
 				Expect(err).ShouldNot(HaveOccurred())
 
-				err = utils.MkdirAll(fs, filepath.Dir(filepath.Join(config.Images.GetActive().MountPoint, constants.GrubConf)), os.ModePerm)
+				err = utils.MkdirAll(fs, filepath.Dir(filepath.Join(config.Images.GetActive().MountPoint, constants.GrubConf)), constants.DirPerm)
 				Expect(err).ShouldNot(HaveOccurred())
 
 				err = fs.WriteFile(filepath.Join(config.Images.GetActive().MountPoint, constants.GrubConf), []byte("console=tty1"), 0644)
@@ -544,10 +544,10 @@ var _ = Describe("Utils", Label("utils"), func() {
 				logger.SetOutput(buf)
 				logger.SetLevel(log.DebugLevel)
 
-				err := utils.MkdirAll(fs, filepath.Dir(filepath.Join(config.Images.GetActive().MountPoint, constants.GrubConf)), os.ModePerm)
+				err := utils.MkdirAll(fs, filepath.Dir(filepath.Join(config.Images.GetActive().MountPoint, constants.GrubConf)), constants.DirPerm)
 				Expect(err).ShouldNot(HaveOccurred())
 
-				err = utils.MkdirAll(fs, filepath.Dir(constants.EfiDevice), os.ModePerm)
+				err = utils.MkdirAll(fs, filepath.Dir(constants.EfiDevice), constants.DirPerm)
 				Expect(err).ShouldNot(HaveOccurred())
 
 				_, _ = fs.Create(filepath.Join(config.Images.GetActive().MountPoint, constants.GrubConf))
@@ -569,7 +569,7 @@ var _ = Describe("Utils", Label("utils"), func() {
 				logger.SetOutput(buf)
 				logger.SetLevel(log.DebugLevel)
 
-				err := utils.MkdirAll(fs, filepath.Dir(filepath.Join(config.Images.GetActive().MountPoint, constants.GrubConf)), os.ModePerm)
+				err := utils.MkdirAll(fs, filepath.Dir(filepath.Join(config.Images.GetActive().MountPoint, constants.GrubConf)), constants.DirPerm)
 				Expect(err).ShouldNot(HaveOccurred())
 
 				_, _ = fs.Create(filepath.Join(config.Images.GetActive().MountPoint, constants.GrubConf))
@@ -590,12 +590,12 @@ var _ = Describe("Utils", Label("utils"), func() {
 				logger := log.New()
 				logger.SetOutput(buf)
 
-				fs.Mkdir("/dev", os.ModePerm)
+				fs.Mkdir("/dev", constants.DirPerm)
 
 				err := utils.MkdirAll(fs, fmt.Sprintf("%s/grub2/", constants.StateDir), 0666)
 				Expect(err).ShouldNot(HaveOccurred())
 
-				err = utils.MkdirAll(fs, filepath.Dir(filepath.Join(config.Images.GetActive().MountPoint, constants.GrubConf)), os.ModePerm)
+				err = utils.MkdirAll(fs, filepath.Dir(filepath.Join(config.Images.GetActive().MountPoint, constants.GrubConf)), constants.DirPerm)
 				Expect(err).ShouldNot(HaveOccurred())
 
 				err = fs.WriteFile(filepath.Join(config.Images.GetActive().MountPoint, constants.GrubConf), []byte("console=tty1"), 0644)
@@ -699,10 +699,10 @@ var _ = Describe("Utils", Label("utils"), func() {
 	})
 	Describe("LoadEnvFile", Label("LoadEnvFile"), func() {
 		BeforeEach(func() {
-			fs.Mkdir("/etc", os.ModePerm)
+			fs.Mkdir("/etc", constants.DirPerm)
 		})
 		It("returns proper map if file exists", func() {
-			err := fs.WriteFile("/etc/envfile", []byte("TESTKEY=TESTVALUE"), os.ModePerm)
+			err := fs.WriteFile("/etc/envfile", []byte("TESTKEY=TESTVALUE"), constants.FilePerm)
 			Expect(err).ToNot(HaveOccurred())
 			envData, err := utils.LoadEnvFile(fs, "/etc/envfile")
 			Expect(err).ToNot(HaveOccurred())
@@ -714,7 +714,7 @@ var _ = Describe("Utils", Label("utils"), func() {
 		})
 
 		It("returns error if it cant unmarshall the env file", func() {
-			err := fs.WriteFile("/etc/envfile", []byte("WHATWHAT"), os.ModePerm)
+			err := fs.WriteFile("/etc/envfile", []byte("WHATWHAT"), constants.FilePerm)
 			Expect(err).ToNot(HaveOccurred())
 			_, err = utils.LoadEnvFile(fs, "/etc/envfile")
 			Expect(err).To(HaveOccurred())


### PR DESCRIPTION
This commit fixes few FS issues in action and elemental tests so proper
file and directory permissions are used within the FS interface.

In addition a bug on CopyImage has been fixed, being more specific about
permissions made it evident. CreateDirStructure utility should not run
for images from file sources (simple file copy).

Signed-off-by: David Cassany <dcassany@suse.com>