### PR TITLE
Remove blkid dependency and limit lsblk usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,20 +44,20 @@ test_deps:
 	go install github.com/onsi/ginkgo/v2/ginkgo
 
 test: $(GINKGO)
-	ginkgo run --label-filter !root --fail-fast --slow-spec-threshold 30s --race --covermode=atomic --coverprofile=coverage.txt -p -r ${PKG}
+	ginkgo run --label-filter !root --slow-spec-threshold 30s --race --covermode=atomic --coverprofile=coverage.txt -p -r ${PKG}
 
 test_root: $(GINKGO)
 ifneq ($(shell id -u), 0)
 	@echo "This tests require root/sudo to run."
 	@exit 1
 else
-	ginkgo run --label-filter root --fail-fast --slow-spec-threshold 30s --race --covermode=atomic --coverprofile=coverage_root.txt -procs=1 -r ${PKG}
+	ginkgo run --label-filter root --slow-spec-threshold 30s --race --covermode=atomic --coverprofile=coverage_root.txt -procs=1 -r ${PKG}
 endif
 
 # Useful test run for local dev. It does not run tests that require root and it does not run tests that require systemctl checks
 # which results in a escalation prompt for privileges. This can block a run until a password or the prompt is cancelled
 test_no_root_no_systemctl:
-	ginkgo run --label-filter '!root && !systemctl' --fail-fast --slow-spec-threshold 30s --race --covermode=atomic --coverprofile=coverage.txt -p -r ${PKG}
+	ginkgo run --label-filter '!root && !systemctl' --slow-spec-threshold 30s --race --covermode=atomic --coverprofile=coverage.txt -p -r ${PKG}
 
 license-check:
 	@.github/license_check.sh

--- a/pkg/action/reset.go
+++ b/pkg/action/reset.go
@@ -64,7 +64,7 @@ func ResetSetup(config *v1.RunConfig) error {
 			partEfi.MountPoint = cnst.EfiDir
 		}
 		partEfi.Name = cnst.EfiPartName
-		config.Partitions = append(config.Partitions, &partEfi)
+		config.Partitions = append(config.Partitions, partEfi)
 	}
 
 	// Only add it if it exists, not a hard requirement
@@ -74,7 +74,7 @@ func ResetSetup(config *v1.RunConfig) error {
 			partOEM.MountPoint = cnst.OEMDir
 		}
 		partOEM.Name = cnst.OEMPartName
-		config.Partitions = append(config.Partitions, &partOEM)
+		config.Partitions = append(config.Partitions, partOEM)
 	} else {
 		config.Logger.Warnf("No OEM partition found")
 	}
@@ -88,7 +88,7 @@ func ResetSetup(config *v1.RunConfig) error {
 		partState.MountPoint = cnst.StateDir
 	}
 	partState.Name = cnst.StatePartName
-	config.Partitions = append(config.Partitions, &partState)
+	config.Partitions = append(config.Partitions, partState)
 	config.Target = partState.Disk
 
 	// Only add it if it exists, not a hard requirement
@@ -98,7 +98,7 @@ func ResetSetup(config *v1.RunConfig) error {
 			partPersistent.MountPoint = cnst.PersistentDir
 		}
 		partPersistent.Name = cnst.PersistentPartName
-		config.Partitions = append(config.Partitions, &partPersistent)
+		config.Partitions = append(config.Partitions, partPersistent)
 	} else {
 		config.Logger.Warnf("No Persistent partition found")
 	}

--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -144,7 +144,7 @@ func (u *UpgradeAction) Run() (err error) { // nolint:gocyclo
 		//  We are updating recovery
 		if u.Config.RecoveryUpgrade {
 			// Try to mount SYSTEM partition, only exists if recovery is squash
-			var recoveryPart v1.Partition
+			var recoveryPart *v1.Partition
 			recoveryPart, err = utils.GetFullDeviceByLabel(u.Config.Runner, u.Config.SystemLabel, 2)
 			if err != nil {
 				// Failure to get the system label, fallback tor recovery label

--- a/pkg/cloudinit/layout_plugin.go
+++ b/pkg/cloudinit/layout_plugin.go
@@ -55,9 +55,19 @@ func layoutPlugin(l logger.Interface, s schema.Stage, fs vfs.FS, console plugins
 			l.Errorf("Exiting, disk not found:\n %s", err.Error())
 			return err
 		}
-		dev = partitioner.NewDisk(partDevice.Disk, partitioner.WithRunner(runner), partitioner.WithLogger(log))
+		dev = partitioner.NewDisk(
+			partDevice.Disk,
+			partitioner.WithRunner(runner),
+			partitioner.WithLogger(log),
+			partitioner.WithFS(fs),
+		)
 	} else if len(strings.TrimSpace(s.Layout.Device.Path)) > 0 {
-		dev = partitioner.NewDisk(s.Layout.Device.Path, partitioner.WithRunner(runner), partitioner.WithLogger(log))
+		dev = partitioner.NewDisk(
+			s.Layout.Device.Path,
+			partitioner.WithRunner(runner),
+			partitioner.WithLogger(log),
+			partitioner.WithFS(fs),
+		)
 	} else {
 		l.Warnf("No target device defined, nothing to do")
 		return nil

--- a/pkg/elemental/elemental.go
+++ b/pkg/elemental/elemental.go
@@ -528,7 +528,7 @@ func (c Elemental) SetDefaultGrubEntry() error {
 		} else if p.MountPoint == "" {
 			return errors.New("state partition not mounted. Cannot set grub env file")
 		} else {
-			part = &p
+			part = p
 		}
 	}
 	grub := utils.NewGrub(c.config)

--- a/pkg/types/v1/config.go
+++ b/pkg/types/v1/config.go
@@ -143,14 +143,14 @@ type RunConfig struct {
 
 // Partition struct represents a partition with its commonly configurable values, size in MiB
 type Partition struct {
-	Label      string `json:"label,omitempty"`
+	Label      string
 	Size       uint
 	Name       string
-	FS         string `json:"fstype,omitempty"`
+	FS         string
 	Flags      []string
-	MountPoint string `json:"mountpoint,omitempty"`
-	Path       string `json:"path,omitempty"`
-	Disk       string `json:"pkname,omitempty"`
+	MountPoint string
+	Path       string
+	Disk       string
 }
 
 type PartitionList []*Partition

--- a/pkg/types/v1/fs.go
+++ b/pkg/types/v1/fs.go
@@ -29,6 +29,7 @@ type FS interface {
 	Stat(name string) (os.FileInfo, error)
 	RemoveAll(path string) error
 	ReadFile(filename string) ([]byte, error)
+	Readlink(name string) (string, error)
 	RawPath(name string) (string, error)
 	Remove(name string) error
 	OpenFile(name string, flag int, perm fs.FileMode) (*os.File, error)

--- a/pkg/utils/lsblk.go
+++ b/pkg/utils/lsblk.go
@@ -1,0 +1,109 @@
+/*
+Copyright © 2022 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"encoding/json"
+	"errors"
+
+	v1 "github.com/rancher-sandbox/elemental/pkg/types/v1"
+)
+
+type jPart struct {
+	Label      string `json:"label,omitempty"`
+	Size       uint64 `json:"size,omitempty"`
+	FS         string `json:"fstype,omitempty"`
+	MountPoint string `json:"mountpoint,omitempty"`
+	Path       string `json:"path,omitempty"`
+	Disk       string `json:"pkname,omitempty"`
+	Type       string `json:"type,omitempty"`
+}
+
+type jParts []*v1.Partition
+
+func (p jPart) Partition() *v1.Partition {
+	// Converts B to MB
+	return &v1.Partition{
+		Label:      p.Label,
+		Size:       uint(p.Size / (1024 * 1024)),
+		FS:         p.FS,
+		Flags:      []string{},
+		MountPoint: p.MountPoint,
+		Path:       p.Path,
+		Disk:       p.Disk,
+	}
+}
+
+func (p *jParts) UnmarshalJSON(data []byte) error {
+	var parts []jPart
+
+	if err := json.Unmarshal(data, &parts); err != nil {
+		return err
+	}
+
+	var partitions jParts
+	for _, part := range parts {
+		// filter only partition or loop devices
+		if part.Type == "part" || part.Type == "loop" {
+			partitions = append(partitions, part.Partition())
+		}
+	}
+	*p = partitions
+	return nil
+}
+
+func unmarshalLsblk(lsblkOut []byte) ([]*v1.Partition, error) {
+	var objmap map[string]*json.RawMessage
+	err := json.Unmarshal(lsblkOut, &objmap)
+	if err != nil {
+		return nil, err
+	}
+
+	if _, ok := objmap["blockdevices"]; !ok {
+		return nil, errors.New("Invalid json object, no 'blockdevices' key found")
+	}
+
+	var parts jParts
+	err = json.Unmarshal(*objmap["blockdevices"], &parts)
+	if err != nil {
+		return nil, err
+	}
+
+	return parts, nil
+}
+
+// GetAllPartitions gets an array of partition devices mapped into v1.Partition
+// objects.
+func GetAllPartitions(runner v1.Runner) (v1.PartitionList, error) {
+	out, err := runner.Run("lsblk", "-p", "-b", "-n", "-J", "--output", "LABEL,SIZE,FSTYPE,MOUNTPOINT,PATH,PKNAME,TYPE")
+	if err != nil {
+		return nil, err
+	}
+
+	return unmarshalLsblk(out)
+}
+
+// GetDevicePartitions gets an array of partition devices mapped into v1.Partition
+// objects.
+func GetDevicePartitions(runner v1.Runner, device string) (v1.PartitionList, error) {
+	out, err := runner.Run("lsblk", "-p", "-b", "-n", "-J", "--output", "LABEL,SIZE,FSTYPE,MOUNTPOINT,PATH,PKNAME,TYPE", device)
+	if err != nil {
+		return nil, err
+	}
+
+	return unmarshalLsblk(out)
+}


### PR DESCRIPTION
This commit removes all blkid calls and wraps lsblk in a more
normalized and generic way. lsblk is only called in two methods:

* GetDevicePartitions: returns a v1.PartitionList with all the
partitions or loop devices for the given device path.

* GetAllPartitions: returns a v1.PartitionList with all the partitions
and loop devices of the host.

Signed-off-by: David Cassany <dcassany@suse.com>